### PR TITLE
Error when using JSPM to retrieve md.data.table

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // support for Browserify
 
 require('angular-material');
-require('./dist/md-data-table.min.js');
+require('./dist/md-data-table.min');
 
 module.exports = 'md.data.table';


### PR DESCRIPTION
Using jspm and md.data.tables, I get this error :
GET http://localhost:5000/jspm_packages/github/daniel-nagy/md-data-table@0.8.11/dist/md-data-table.min.js.js 404 (Not Found)
-> There is to many ".js"

Solution : remove it from index.js
It then works correctly