### PR TITLE
Fixed bug in mdTablePagination.js

### DIFF
--- a/src/scripts/mdTablePagination.js
+++ b/src/scripts/mdTablePagination.js
@@ -96,7 +96,7 @@ function mdTablePagination() {
     };
     
     $scope.$watch('$pagination.limit', function (newValue, oldValue) {
-      if(newValue === oldValue) {
+      if(oldValue == undefined || newValue === oldValue) {
         return;
       }
       


### PR DESCRIPTION
The watcher for $pagination.limit doesn't check if the oldValue is undefined and causes the page to resolve to NaN.