### PR TITLE
limitSelect should be optional

### DIFF
--- a/src/scripts/mdTablePagination.js
+++ b/src/scripts/mdTablePagination.js
@@ -95,6 +95,14 @@ function mdTablePagination() {
       return self.pageSelect;
     };
     
+    self.showLimitSelect = function () {
+        if($attrs.hasOwnProperty('mdLimitSelect') && $attrs.mdLimitSelect === '') {
+          return true;
+        }
+        
+        return self.limitSelect;
+      };
+      
     $scope.$watch('$pagination.limit', function (newValue, oldValue) {
       if(newValue === oldValue) {
         return;
@@ -115,6 +123,7 @@ function mdTablePagination() {
       limit: '=mdLimit',
       page: '=mdPage',
       pageSelect: '=?mdPageSelect',
+      limitSelect: '=?mdLimitSelect',
       onPaginate: '=?mdOnPaginate',
       options: '=mdOptions',
       total: '@mdTotal'

--- a/src/templates/md-table-pagination.html
+++ b/src/templates/md-table-pagination.html
@@ -4,9 +4,9 @@
   <md-option ng-repeat="num in $pagination.range($pagination.pages()) track by $index" ng-value="$index + 1">{{$index + 1}}</md-option>
 </md-select>
 
-<span class="label">{{ $pagination.$label['rowsPerPage'] }}</span>
+<span class="label" ng-if="$pagination.showLimitSelect()">{{ $pagination.$label['rowsPerPage'] }}</span>
 
-<md-select class="md-table-select" ng-model="$pagination.limit" md-container-class="md-pagination-select" aria-label="Rows" placeholder="{{$pagination.options ? $pagination.options[0] : 5}}">
+<md-select class="md-table-select" ng-if="$pagination.showLimitSelect()" ng-model="$pagination.limit" md-container-class="md-pagination-select" aria-label="Rows" placeholder="{{$pagination.options ? $pagination.options[0] : 5}}">
   <md-option ng-repeat="rows in $pagination.options ? $pagination.options : [5, 10, 15]" ng-value="rows">{{rows}}</md-option>
 </md-select>
 


### PR DESCRIPTION
Hi there,

Thanks for the great work on `md-data-table`! I have a small change request:

If your UI shows a pagination component, then implicit in the backend (REST API or whatever) is that there is a capability to change which page is being displayed. Therefore it makes sense to display the previous/next buttons and even the pageSelect dropdown by default.

However there is no such implication regarding row limit. A REST API does not need to expose the option for the user to choose how many rows are returned. In fact, doing so opens up an attack vector and so the API must include additional checks to prevent too many rows being requested.

Given this, it doesn't seem to make sense to have the limitSelect dropdown displayed by default? Especially if there is no option to turn it off?

I have added a new option 'md-limit-select', modelled after your existing 'md-page-select', that is off by default but can be added to display the limitSelect dropdown.

I realize this is a breaking change, but one that makes sense, I think?