### PR TITLE
Fix md-datepicker icon color in toolbar

### DIFF
--- a/src/styles/md-table-toolbar.less
+++ b/src/styles/md-table-toolbar.less
@@ -23,6 +23,7 @@ md-toolbar.md-table-toolbar {
     
     md-icon {
       color: @md-dark-icon;
+      fill: @md-dark-icon;
     }
     
     > .md-button.md-icon-button {


### PR DESCRIPTION
Fix md-datepicker icon color in md-toolbar

![image](https://cloud.githubusercontent.com/assets/6898003/13581102/5b4a12de-e4b6-11e5-812a-f442f2a522e1.png)
