### PR TITLE
Changing way of passing onReorder function

### DIFF
--- a/src/scripts/mdColumn.js
+++ b/src/scripts/mdColumn.js
@@ -63,7 +63,7 @@ function mdColumn($compile, $mdUtil) {
 
         if(angular.isFunction(headCtrl.onReorder)) {
           $mdUtil.nextTick(function () {
-            headCtrl.onReorder(headCtrl.order);
+            headCtrl.onReorder({order: headCtrl.order});
           });
         }
       });

--- a/src/scripts/mdHead.js
+++ b/src/scripts/mdHead.js
@@ -123,7 +123,7 @@ function mdHead($compile) {
     restrict: 'A',
     scope: {
       order: '=?mdOrder',
-      onReorder: '=?mdOnReorder'
+      onReorder: '&?mdOnReorder'
     }
   };
 }


### PR DESCRIPTION
Hello

I've found issue when I wanted use reorder function. There was problem with passing scope to this function. I had something like this:

`md-on-reorder="controller.fetchClients"`

```
fetchClients() {
console.log(this.$q); 
}
```

When I called controller.fetchClients in template it gives in console $qProvider. 
When it's called from md-data-table it gives undefined.
