### PR TITLE
Callback when user click outside editor dialog.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -33,6 +33,8 @@
           <md-checkbox ng-model="options.autoSelect">Auto Selection</md-checkbox>
           <md-checkbox ng-model="options.decapitate">Decapitate</md-checkbox>
           <md-checkbox ng-model="options.largeEditDialog">Lard Edit Dialogs</md-checkbox>
+          <md-checkbox ng-model="options.dialogClickOutsideToClose">Click Outside To Close Dialog</md-checkbox>
+          <md-checkbox ng-model="options.dialogClickOutsideCallback">Click Outside CallBack</md-checkbox>
           <md-checkbox ng-model="options.boundaryLinks">Pagination Boundary Links</md-checkbox>
           <md-checkbox ng-model="options.limitSelect" ng-click="toggleLimitOptions()">Pagination Limit Select</md-checkbox>
           <md-checkbox ng-model="options.pageSelect">Pagination Page Select</md-checkbox>

--- a/app/scripts/nutritionController.js
+++ b/app/scripts/nutritionController.js
@@ -1,4 +1,4 @@
-angular.module('nutritionApp').controller('nutritionController', ['$http', '$mdEditDialog', '$q', '$timeout', '$scope', function ($http, $mdEditDialog, $q, $timeout, $scope) {
+angular.module('nutritionApp').controller('nutritionController', ['$http', '$mdEditDialog', '$q', '$timeout', '$scope', '$mdToast', function ($http, $mdEditDialog, $q, $timeout, $scope, $mdToast) {
   'use strict';
 
   $scope.options = {
@@ -111,6 +111,17 @@ angular.module('nutritionApp').controller('nutritionController', ['$http', '$mdE
 
   $scope.editComment = function (event, dessert) {
     event.stopPropagation();
+    var clickOutsideCallback;
+    if ($scope.options.dialogClickOutsideCallback) {
+      clickOutsideCallback = function () {
+        $mdToast.show(
+          $mdToast.simple()
+            .content('Clicked outside')
+            .position('top right')
+            .hideDelay(3000)
+        );
+      };
+    }
 
     var dialog = {
       // messages: {
@@ -121,6 +132,8 @@ angular.module('nutritionApp').controller('nutritionController', ['$http', '$mdE
       save: function (input) {
         dessert.comment = input.$modelValue;
       },
+      clickOutsideToClose: $scope.options.dialogClickOutsideToClose,
+      clickOutsideCallback: clickOutsideCallback,
       targetEvent: event,
       title: 'Add a comment',
       validators: {

--- a/src/scripts/mdEditDialog.js
+++ b/src/scripts/mdEditDialog.js
@@ -74,9 +74,17 @@ function mdEditDialog($compile, $controller, $document, $mdUtil, $q, $rootScope,
     }
     
     if(options.clickOutsideToClose) {
-      backdrop.on('click', function () {
-        element.remove();
-      });
+      if (angular.isFunction(options.clickOutsideCallback)) {
+        backdrop.on('click', function () {
+          options.clickOutsideCallback();
+          element.remove();
+        });
+      }
+      else {
+        backdrop.on('click', function () {
+          element.remove();
+        });
+      }
     }
     
     if(options.escToClose) {


### PR DESCRIPTION
It provides a way to call a function when clicking outside the editor. 
This can be used to resolve #416 whithout using ng-blur on "Roll Your Own" Edit Dialogs.

To use the new functionality simply enable "clickOutsideToClose" and suply a "clickOutsideCallback" function to be called when clicking outside editor dialog.

The Demo has been update to explain this new functionality.